### PR TITLE
Minotr edits: typo in example and URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,6 +10,7 @@ Description: Covariance is of universal prevalence across various disciplines wi
     For an introduction to covariance in multivariate statistical analysis,
     see Schervish (1987) <doi:10.1214/ss/1177013111>.
 License: GPL (>=3)
+URL: https://github.com/kyoustat/CovTools
 Encoding: UTF-8
 LazyData: true
 Depends: R (>= 2.14.0)

--- a/R/CovEst.adaptive.R
+++ b/R/CovEst.adaptive.R
@@ -25,7 +25,7 @@
 #'
 #' out1 <- CovEst.adaptive(data, thr=0.1)  # threshold value 0.1
 #' out2 <- CovEst.adaptive(data, thr=0.5)  # threshold value 0.5
-#' out3 <- CovEst.adaptive(data, thr=0.5)  # threshold value 0.9
+#' out3 <- CovEst.adaptive(data, thr=0.1)  # threshold value 0.9
 #' out4 <- CovEst.adaptive(data, thr=mthr) # automatic threshold checking
 #'
 #' ## visualize 4 estimated matrices

--- a/man/CovEst.adaptive.Rd
+++ b/man/CovEst.adaptive.Rd
@@ -36,7 +36,7 @@ mthr <- seq(from=0.01,to=0.99,length.out=10)
 
 out1 <- CovEst.adaptive(data, thr=0.1)  # threshold value 0.1
 out2 <- CovEst.adaptive(data, thr=0.5)  # threshold value 0.5
-out3 <- CovEst.adaptive(data, thr=0.5)  # threshold value 0.9
+out3 <- CovEst.adaptive(data, thr=0.9)  # threshold value 0.9
 out4 <- CovEst.adaptive(data, thr=mthr) # automatic threshold checking
 
 ## visualize 4 estimated matrices

--- a/src/rcpp_2003LW.cpp
+++ b/src/rcpp_2003LW.cpp
@@ -40,13 +40,14 @@ arma::mat covest_2003LW_computePi(arma::mat Y, arma::vec Ybar, arma::mat matS){
   double inners = 0.0;
   arma::mat matPi(dimN,dimN,fill::zeros);
   for (int i=0;i<dimN;i++){
-    for (int j=0;j<dimN;j++){
+    for (int j=i;j<dimN;j++){
       tmpval = 0.0;
       for (int t=0;t<dimT;t++){
         inners = (Y(i,t)-Ybar(i))*(Y(j,t)-Ybar(j)) - matS(i,j);
         tmpval += inners*inners;
       }
       matPi(i,j) = tmpval/static_cast<double>(dimT);
+      if(i!=j) matPi(j,i) = tmpval/static_cast<double>(dimT);
     }
   }
 


### PR DESCRIPTION
Just fixing a typo in the example, and adding the URL to your github